### PR TITLE
Add setup.py to make the package installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from __future__ import with_statement
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+import tikzmagic
+
+classifiers = [
+    "Programming Language :: Python :: 2",
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering :: Visualization",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Utilities",
+    "Framework :: IPython"
+]
+
+with open("README.md", "r") as fp:
+    long_description = fp.read()
+
+setup(
+    name="ipython-tikzmagic",
+    version=tikzmagic.__version__,
+    author=tikzmagic.__author__,
+    url="https://github.com/mkrphys/ipython-tikzmagic",
+    py_modules=["tikzmagic"],
+    description="IPython magics for generating figures with TikZ",
+    long_description=long_description,
+    license="BSD",
+    classifiers=classifiers
+)

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -43,6 +43,9 @@ from IPython.core.magic_arguments import (
 )
 from IPython.utils.py3compat import unicode_to_str
 
+__author__ = "Michael Kraus"
+__version__ = "0.1.0"
+
 _mimetypes = {'png' : 'image/png',
               'svg' : 'image/svg+xml',
               'jpg' : 'image/jpeg',


### PR DESCRIPTION
I added setup.py file and some meta data in order to make this package installable as:

```
python setup.py install
```

Would you like to add this to PyPI so that the package could be installed as:

```
pip install ipython-tikzmagic
```

It would really make this package more visible and easier to use in different environments. If you want, I can add the package to PyPI and/or add `setup.cfg` file to make the process a bit easier.

Also, probably you want to check all the metadata I added. Sorry for any mistakes. For instance, I just put version number 0.1.0, maybe you want something else.

Anyway, thanks for this great package!
