### PR TITLE
setup.py: require ipython; remove import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ try:
 except ImportError:
     from distutils.core import setup
 
-import tikzmagic
-
 classifiers = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
@@ -21,14 +19,20 @@ classifiers = [
 with open("README.md", "r") as fp:
     long_description = fp.read()
 
+__author__ = "Michael Kraus"
+__version__ = "0.1.1"
+
 setup(
     name="ipython-tikzmagic",
-    version=tikzmagic.__version__,
-    author=tikzmagic.__author__,
+    version=__version__,
+    author=__author__,
     url="https://github.com/mkrphys/ipython-tikzmagic",
     py_modules=["tikzmagic"],
     description="IPython magics for generating figures with TikZ",
     long_description=long_description,
     license="BSD",
-    classifiers=classifiers
+    classifiers=classifiers,
+    install_requires=[
+        "ipython",
+    ]
 )

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -43,8 +43,12 @@ from IPython.core.magic_arguments import (
 )
 from IPython.utils.py3compat import unicode_to_str
 
-__author__ = "Michael Kraus"
-__version__ = "0.1.0"
+try:
+    import pkg_resources  # part of setuptools
+    __version__ = pkg_resources.require("ipython-tikzmagic")[0].version
+except ImportError:
+    __version__ = 'unknown'
+
 
 _mimetypes = {'png' : 'image/png',
               'svg' : 'image/svg+xml',


### PR DESCRIPTION
Fix setup.py so that `pip install ipython-tikzmagic` works from an empty
virtualenv (python2 or python3).

* Update setup.py so it requires ipython.
* Upadte setup.py so it no longer imports tikzmagic.
* Update tikzmagic.py so it __version__ from pkg_resources (setuptools).
* Move __author__ from tikzmagic.py to setup.py; unlike version, we
  can't pull it easily from pkg_resources.
* Bump version to 0.1.1.