### PR TITLE
Fix for ImageMagick path, options for \tikzpicture and show how to correctly use preamble

### DIFF
--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -211,6 +211,9 @@ class TikzMagics(Magics):
     @argument('-i', '--imagemagick', action='store', type=str, default='convert',
         help='Name of ImageMagick executable, optionally with full path. Default is "convert"'
         )
+    @argument('-po', '--pictureoptions', action='store', type=str, default='',
+        help='Additional arguments to pass to the \\tikzpicture command.'
+        )
 
     @needs_local_scope
     @argument(
@@ -262,6 +265,7 @@ class TikzMagics(Magics):
         tikz_library = args.library.split(',')
         latex_package = args.package.split(',')
         imagemagick_path = args.imagemagick
+        picture_options = args.pictureoptions
  
         # arguments 'code' in line are prepended to the cell lines
         if cell is None:
@@ -308,7 +312,7 @@ class TikzMagics(Magics):
         
         tex.append('''
 \\begin{document}
-\\begin{tikzpicture}[scale=%(scale)s]
+\\begin{tikzpicture}[scale=%(scale)s,%(picture_options)s]
         ''' % locals())
         
         tex.append(code)

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -193,7 +193,7 @@ class TikzMagics(Magics):
         )
     @argument(
         '-x', '--preamble', action='store', type=str, default='',
-        help='LaTeX preamble to insert before tikz figure, e.g., -x $preamble, with preamble some string variable.'
+        help='LaTeX preamble to insert before tikz figure, e.g., -x "$preamble", with preamble some string variable.'
         )
     @argument(
         '-p', '--package', action='store', type=str, default='',

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -159,12 +159,13 @@ class TikzMagics(Magics):
         chdir(current_dir)
         
  
-    def _convert_png_to_jpg(self, dir):
+    def _convert_png_to_jpg(self, dir, imagemagick_path):
         current_dir = getcwd()
         chdir(dir)
         
         try:
-            retcode = call("convert tikz.png -quality 100 -background white -flatten tikz.jpg", shell=True)
+            retcode = call("%s tikz.png -quality 100 -background white -flatten tikz.jpg"
+                            % imagemagick_path, shell=True)
             if retcode != 0:
                 print("convert terminated with signal", -retcode, file=sys.stderr)
         except OSError as e:
@@ -206,6 +207,9 @@ class TikzMagics(Magics):
     @argument(
         '-S', '--save', action='store', type=str, default=None,
         help='Save a copy to file, e.g., -S filename. Default is None'
+        )
+    @argument('-i', '--imagemagick', action='store', type=str, default='convert',
+        help='Name of ImageMagick executable, optionally with full path. Default is "convert"'
         )
 
     @needs_local_scope
@@ -257,6 +261,7 @@ class TikzMagics(Magics):
         encoding = args.encoding
         tikz_library = args.library.split(',')
         latex_package = args.package.split(',')
+        imagemagick_path = args.imagemagick
  
         # arguments 'code' in line are prepended to the cell lines
         if cell is None:
@@ -282,7 +287,7 @@ class TikzMagics(Magics):
         
         tex = []
         tex.append('''
-\\documentclass[convert={%(add_params)ssize=%(width)sx%(height)s,outext=.png},border=0pt]{standalone}
+\\documentclass[convert={convertexe={%(imagemagick_path)s},%(add_params)ssize=%(width)sx%(height)s,outext=.png},border=0pt]{standalone}
 \\usepackage{tikz}
         ''' % locals())
         
@@ -327,7 +332,7 @@ class TikzMagics(Magics):
             return
 
         if plot_format == 'jpg' or plot_format == 'jpeg':
-            self._convert_png_to_jpg(plot_dir)
+            self._convert_png_to_jpg(plot_dir, imagemagick_path)
         elif plot_format == 'svg':
             self._convert_pdf_to_svg(plot_dir)
 

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -214,6 +214,10 @@ class TikzMagics(Magics):
     @argument('-po', '--pictureoptions', action='store', type=str, default='',
         help='Additional arguments to pass to the \\tikzpicture command.'
         )
+        
+    @argument('--showlatex', action='store_true',
+        help='Show the LATeX file instead of generating image, for debugging LaTeX errors.'
+        )
 
     @needs_local_scope
     @argument(
@@ -323,6 +327,10 @@ class TikzMagics(Magics):
         ''')
         
         code = str('').join(tex)
+        
+        if args.showlatex:
+            print(code)
+            return
 
         latex_log = self._run_latex(code, encoding, plot_dir)
         


### PR DESCRIPTION
I was attempting to reproduce this [control systems example](http://www.texample.net/tikz/examples/control-system-principles/) within a Jupyter notebook, on a Windows machine. I ran into the following problems, all of which are addressed in this pull request:

- I need to override the location of ImageMagick executable (it is called `magick` on my system, whereas the default on many systems seems to be `convert`). A new option `--imagemagick` has been added to enable this.
- I need to be able to pass additional options to the `\tikzpicture` command. A new option `--pictureoptions` has been added to enable this.
- I created a multi-line preamble, but had trouble passing this to the tikz magic. The solution was to surround it in double quotes, so I added this to the documentation.

I'm happy to change any of the options if necessary, or to split this PR into 3 separate ones covering each of the issues.