### PR TITLE
Adds a workaround for the fact that pdflatex emits a warning

### DIFF
--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -364,7 +364,7 @@ class TikzMagics(Magics):
             tex.append(
                 dedent(
                     r"""
-                    \definecolor{verydark}{rgb} {0.90,0.01,0.01}
+                    \definecolor{verydark}{rgb} {0.00,0.01,0.01}
                     \tikzset{
                         notquiteblack/.style={color=verydark}
                     }

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -27,7 +27,6 @@ Usage
 #-----------------------------------------------------------------------------
 from __future__ import print_function
 from builtins import str
-import subprocess
 import sys
 import tempfile
 from glob import glob
@@ -126,11 +125,7 @@ class TikzMagics(Magics):
             # search path (otherwise we would lose access to all packages)
 
         try:
-            retcode = call("pdflatex --shell-escape tikz.tex",
-                           shell=True,
-                           env=env,
-                           stdout=subprocess.DEVNULL,
-                           stderr=subprocess.DEVNULL)
+            retcode = call("pdflatex --shell-escape tikz.tex", shell=True, env=env)
             if retcode != 0:
                 print("LaTeX terminated with signal", -retcode, file=sys.stderr)
                 ret_log = True

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -142,12 +142,9 @@ class TikzMagics(Magics):
             except IOError:
                 print("No log file generated.", file=sys.stderr)
 
-            chdir(current_dir)
-            return log
+        chdir(current_dir)
 
-        else:
-            chdir(current_dir)
-            return None
+        return log
 
 
     def _convert_pdf_to_svg(self, dir):


### PR DESCRIPTION
As it turns out, it's ok to just ignore that warning.  I didn't realize this until I had already written this, so I figured I'd push it just in case somebody in the future cares.

What I really wanted to do was prevent stdout and stderr from the subprocess from showing up in the notebook (they're what sent me on this goose chase).