### PR TITLE
Remove delimiters around picture_options

### DIFF
--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -296,7 +296,11 @@ class TikzMagics(Magics):
         pgfplots_library = args.pgfplotslibrary.split(',')
         latex_package = args.package.split(',')
         imagemagick_path = args.imagemagick
-        picture_options = args.pictureoptions
+        p_o = args.pictureoptions
+        # strip delimiters
+        if p_o[0] in "'\"" and p_o[0] == p_o[-1] and p_o[0] not in p_o[1:-1]:
+            p_o = p_o[1:-1]
+        picture_options = p_o
         tikz_options = args.tikzoptions
 
         # arguments 'code' in line are prepended to the cell lines


### PR DESCRIPTION
Currently not possible to use -po option with space characters : @magic_arguments split around these. 

e.g. 
```
%%tikz -po line width=3pt
\draw (0,0) -- (1,0) ;
```
would be converted to 
```
    \begin{tikzpicture}[scale=1,line]
    width=3pt\draw (0,0) -- (1,0) ;

    \end{tikzpicture}
```

I think the easiest workaround is to allow quotes or double quotes around po arguments, and to remove them. The code is quite self-explanatory. With this, you would write : 
```
%%tikz -po "line width=3pt"
\draw (0,0) -- (1,0) ;
```