### PR TITLE
quantikz support

### DIFF
--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -226,7 +226,7 @@ class TikzMagics(Magics):
     @argument('-i', '--imagemagick', action='store', type=str, default='convert',
         help='Name of ImageMagick executable, optionally with full path. Default is "convert"'
         )
-    @argument('-po', '--pictureoptions', action='store', type=str, default='',
+    @argument('-po', '--pictureoptions', action='store', type=str, default='', nargs='*',
         help='Additional arguments to pass to the \\tikzpicture command.'
         )
 
@@ -360,11 +360,13 @@ class TikzMagics(Magics):
         if args.preamble is not None:
             tex.append('''%s\n''' % args.preamble)
 
-        if scale  == 1:
-            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[%(picture_options)s]\n''' % locals())
-        else:
-            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]\n''' % locals())
 
+        tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}['''  % locals())
+        if scale != 1:
+             tex.append('''scale=%(scale)s,'''% locals())
+        for picture_option in picture_options:
+            tex.append('''%(picture_option)s '''  % locals())
+        tex.append(''']\n''')
         tex.append(code)
 
         if code[-1] != '\n':

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -237,6 +237,9 @@ class TikzMagics(Magics):
     @argument('-ct', '--circuitikz', action='store_true',
         help='Use CircuiTikZ package instead of regular TikZ.'
         )
+    @argument('-qt', '--quantikz', action='store_true',
+        help='Use QuanTikZ package instead of regular TikZ.'
+        )
     @argument('-eu', '--tkz-euclide', action='store_true',
         help='Use tkz-euclide package instead of regular TikZ.'
         )
@@ -325,6 +328,9 @@ class TikzMagics(Magics):
         if args.circuitikz:
             tikz_env = 'circuitikz'
             tikz_package = 'circuitikz'
+        elif args.quantikz:
+            tikz_env = 'quantikz'
+            tikz_package = 'quantikz'
         elif args.tkz_euclide:
             tikz_env = 'tikzpicture'
             tikz_package = 'tkz-euclide'

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -331,7 +331,7 @@ class TikzMagics(Magics):
         elif args.quantikz:
             tikz_env = 'quantikz'
             tikz_package = 'tikz'
-            library.append('quantikz')
+            tikz_library.append('quantikz')
         elif args.tkz_euclide:
             tikz_env = 'tikzpicture'
             tikz_package = 'tkz-euclide'

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -245,7 +245,7 @@ class TikzMagics(Magics):
         )
 
     @argument('--tikzoptions', action='store', type=str, default='',
-        help='Options to pass when loading TikZ or CircuiTikZ package.'
+        help='Options to pass when loading TikZ. CircuiTikZ, or QuanTikZ packages.'
         )
 
     @needs_local_scope
@@ -330,7 +330,7 @@ class TikzMagics(Magics):
             tikz_package = 'circuitikz'
         elif args.quantikz:
             tikz_env = 'quantikz'
-            tikz_package = 'quantikz'
+            tikz_package = 'tikz'
         elif args.tkz_euclide:
             tikz_env = 'tikzpicture'
             tikz_package = 'tkz-euclide'

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -361,9 +361,9 @@ class TikzMagics(Magics):
             tex.append('''%s\n''' % args.preamble)
 
         if scale  == 1:
-            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[%(picture_options)s]''' % locals())
+            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[%(picture_options)s]\n''' % locals())
         else:
-            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]''' % locals())
+            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]\n''' % locals())
 
         tex.append(code)
 

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -204,7 +204,7 @@ class TikzMagics(Magics):
         help='Text encoding, e.g., -e utf-8.'
         )
     @argument(
-        '-x', '--preamble', action='store', type=str, default='',
+        '-x', '--preamble', action='store', type=str, default='',nargs='*',
         help='LaTeX preamble to insert before tikz figure, e.g., -x "$preamble", with preamble some string variable.'
         )
     @argument(
@@ -359,7 +359,9 @@ class TikzMagics(Magics):
                 tex.append("\\usepgfplotslibrary{%s}\n" % lib)
 
         if args.preamble is not None:
-            tex.append('''%s\n''' % args.preamble)
+            # tex.append('''%s\n''' % args.preamble)
+            for preamble in args.preamble:
+                tex.append('''%(preamble)s '''  % locals())
 
 
         tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}['''  % locals())

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -331,7 +331,10 @@ class TikzMagics(Magics):
         elif args.quantikz:
             tikz_env = 'quantikz'
             tikz_package = 'tikz'
-            tikz_library.append('quantikz')
+            if tikz_library != [""]:
+                tikz_library.append('quantikz')
+            else:
+                tikz_library = ['quantikz']
         elif args.tkz_euclide:
             tikz_env = 'tikzpicture'
             tikz_package = 'tkz-euclide'
@@ -359,9 +362,9 @@ class TikzMagics(Magics):
                 tex.append("\\usepgfplotslibrary{%s}\n" % lib)
 
         if args.preamble is not None:
-            # tex.append('''%s\n''' % args.preamble)
             for preamble in args.preamble:
                 tex.append('''%(preamble)s '''  % locals())
+            tex.append('\n')
 
 
         tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}['''  % locals())

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -366,8 +366,9 @@ class TikzMagics(Magics):
 
         tex.append(code)
 
-        tex.append('''
-\\end{%(tikz_env)s}
+        if code[-1] != '\n':
+            tex.append('\n')
+        tex.append('''\\end{%(tikz_env)s}
 \\end{document}
 ''' % locals())
 

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -331,6 +331,7 @@ class TikzMagics(Magics):
         elif args.quantikz:
             tikz_env = 'quantikz'
             tikz_package = 'tikz'
+            library.append('quantikz')
         elif args.tkz_euclide:
             tikz_env = 'tikzpicture'
             tikz_package = 'tkz-euclide'

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -360,9 +360,10 @@ class TikzMagics(Magics):
         if args.preamble is not None:
             tex.append('''%s\n''' % args.preamble)
 
-        tex.append('''\\begin{document}
-\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]
-''' % locals())
+        if scale is not None:
+            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]''' % locals())
+        else:
+            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[%(picture_options)s]''' % locals())
 
         tex.append(code)
 

--- a/tikzmagic.py
+++ b/tikzmagic.py
@@ -360,10 +360,10 @@ class TikzMagics(Magics):
         if args.preamble is not None:
             tex.append('''%s\n''' % args.preamble)
 
-        if scale is not None:
-            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]''' % locals())
-        else:
+        if scale  == 1:
             tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[%(picture_options)s]''' % locals())
+        else:
+            tex.append('''\\begin{document}\n\\begin{%(tikz_env)s}[scale=%(scale)s,%(picture_options)s]''' % locals())
 
         tex.append(code)
 


### PR DESCRIPTION
This pull request:
1. Adds support for quantikz (https://ctan.org/pkg/quantikz) which is a TikZ package for drawing quantum circuit diagrams. The flag '-qt' or '--quantikz' load the TikZ library quantikz and replace \begin{tikzpicture} and \end{tikzpicture} with \begin{quantikz} and \end{quantikz}, respectively. 

```
%%tikz --quantikz
\lstick{$\ket{0}$} & \gate{H} & \ctrl{1} & \gate{U} & \ctrl{1} & \swap{2} & \ctrl{1} & \qw \\
\lstick{$\ket{0}$} & \gate{H} & \targ{} & \octrl{-1} & \control{} & \qw & \octrl{1} & \qw \\
&&&&&\targX{} & \gate{U} & \qw
```
![image](https://github.com/mkrphys/ipython-tikzmagic/assets/5942894/cce7591e-86fa-4f85-b557-545b5571fe37)

2. Removes the newline at the end of the code in tikzmagic which caused an error in quantikz (and as far as I can tell is not necessary). For example, this is the latex output of one of the ipython-tikzmagic examples before the PR:
```
%%tikz --showlatex
\draw (0,0) rectangle (1,1);
\filldraw (0.5,0.5) circle (.1);
```
```
\documentclass[convert={convertexe={convert},density=300,size=400x240,outext=.png},border=0pt]{standalone}
\usepackage[]{tikz}

\begin{document}
\begin{tikzpicture}[scale=1,]
\draw (0,0) rectangle (1,1);
\filldraw (0.5,0.5) circle (.1);

\end{tikzpicture}
\end{document}
```
and after:
```
\documentclass[convert={convertexe={convert},density=300,size=400x240,outext=.png},border=0pt]{standalone}
\usepackage[]{tikz}

\begin{document}
\begin{tikzpicture}[]
\draw (0,0) rectangle (1,1);
\filldraw (0.5,0.5) circle (.1);
\end{tikzpicture}
\end{document}
```
3. Removes the scale option output if no scaling is provided as seen in the example above. 

4. Enables multiple argument preambles and parameters options. This would address #24 and #38  Eg. 

```
%%tikz --pictureoptions rounded corners,ultra thick
\shade[top color=yellow,bottom color=black] (0,0) rectangle +(2,1);
\shade[left color=yellow,right color=black] (3,0) rectangle +(2,1);
\shadedraw[inner color=yellow,outer color=black,draw=yellow] (6,0) rectangle +(2,1);
\shade[ball color=green] (9,.5) circle (.5cm);
```
![image](https://github.com/mkrphys/ipython-tikzmagic/assets/5942894/ee398935-fb7b-400e-8b6f-9cac87b60802)

```
%%tikz -qt -x \tikzset{operator/.append style={fill=red!20},my label/.append style={above right,xshift=0.3cm},phase label/.append style={label position=above}}
& \gate{H} & \phase{\beta} & \gate{H} & \meter{\ket{\pm}}
```
![image](https://github.com/mkrphys/ipython-tikzmagic/assets/5942894/7f45e6c4-8516-4d60-acef-f2f7cf4c48a1)

Thanks for considering merging this, and let me know if you suggest any changes. 